### PR TITLE
Update boost ai mod 

### DIFF
--- a/Mods/AI speed up - limit on map heroes/Content/Config/difficulty.json
+++ b/Mods/AI speed up - limit on map heroes/Content/Config/difficulty.json
@@ -1,0 +1,348 @@
+//Configured difficulty
+{
+	"ai":
+	{
+		"pawn":
+		{
+			"resources": { "wood" : 8, "mercury": 1, "ore": 8, "sulfur": 1, "crystal": 1, "gems": 1, "gold": 16000, "mithril": 0 },
+			"globalBonuses":
+			[
+				{
+					"type" : "HERO_EXPERIENCE_GAIN_PERCENT",
+					"val" : 24,
+					"duration" : "PERMANENT",
+					"sourceType" : "OTHER"
+				},
+				{
+					"type" : "CREATURE_GROWTH_PERCENT",
+					"val" : 12,
+					"duration" : "PERMANENT",
+					"sourceType" : "OTHER"
+				},
+				{
+					"type" : "GENERATE_RESOURCE",
+					"subtype" : "resource.gold",
+					"val" : 185,
+					"duration" : "PERMANENT",
+					"sourceType" : "OTHER"
+				},
+								{
+					"type" : "GENERATE_RESOURCE",
+					"subtype" : "resource.wood",
+					"val" : 1,
+					"duration" : "PERMANENT",
+					"sourceType" : "OTHER"
+				},
+				{
+					"type" : "GENERATE_RESOURCE",
+					"subtype" : "resource.ore",
+					"val" : 1,
+					"duration" : "PERMANENT",
+					"sourceType" : "OTHER"
+				},
+				{
+					"type" : "GENERATE_RESOURCE",
+					"subtype" : "resource.mercury",
+					"val" : 1,
+					"duration" : "PERMANENT",
+					"sourceType" : "OTHER"
+				},
+				{
+					"type" : "GENERATE_RESOURCE",
+					"subtype" : "resource.crystal",
+					"val" : 1,
+					"duration" : "PERMANENT",
+					"sourceType" : "OTHER"
+				},
+				{
+					"type" : "GENERATE_RESOURCE",
+					"subtype" : "resource.gems",
+					"val" : 1,
+					"duration" : "PERMANENT",
+					"sourceType" : "OTHER"
+				},
+				{
+					"type" : "GENERATE_RESOURCE",
+					"subtype" : "resource.sulfur",
+					"val" : 1,
+					"duration" : "PERMANENT",
+					"sourceType" : "OTHER"
+				},
+
+			],
+		},
+	"knight":
+		{
+			"resources": { "wood" : 10, "mercury": 1, "ore": 10, "sulfur": 1, "crystal": 1, "gems": 1, "gold": 20000, "mithril": 0 },
+			"globalBonuses":
+			[
+				{
+					"type" : "HERO_EXPERIENCE_GAIN_PERCENT",
+					"val" : 30,
+					"duration" : "PERMANENT",
+					"sourceType" : "OTHER"
+				},
+				{
+					"type" : "CREATURE_GROWTH_PERCENT",
+					"val" : 15,
+					"duration" : "PERMANENT",
+					"sourceType" : "OTHER"
+				},
+				{
+					"type" : "GENERATE_RESOURCE",
+					"subtype" : "resource.gold",
+					"val" : 1000,
+					"duration" : "PERMANENT",
+					"sourceType" : "OTHER"
+				},
+				{
+					"type" : "GENERATE_RESOURCE",
+					"subtype" : "resource.wood",
+					"val" : 1,
+					"duration" : "PERMANENT",
+					"sourceType" : "OTHER"
+				},
+				{
+					"type" : "GENERATE_RESOURCE",
+					"subtype" : "resource.ore",
+					"val" : 1,
+					"duration" : "PERMANENT",
+					"sourceType" : "OTHER"
+				},
+				{
+					"type" : "GENERATE_RESOURCE",
+					"subtype" : "resource.mercury",
+					"val" : 1,
+					"duration" : "PERMANENT",
+					"sourceType" : "OTHER"
+				},
+				{
+					"type" : "GENERATE_RESOURCE",
+					"subtype" : "resource.crystal",
+					"val" : 1,
+					"duration" : "PERMANENT",
+					"sourceType" : "OTHER"
+				},
+				{
+					"type" : "GENERATE_RESOURCE",
+					"subtype" : "resource.gems",
+					"val" : 1,
+					"duration" : "PERMANENT",
+					"sourceType" : "OTHER"
+				},
+				{
+					"type" : "GENERATE_RESOURCE",
+					"subtype" : "resource.sulfur",
+					"val" : 1,
+					"duration" : "PERMANENT",
+					"sourceType" : "OTHER"
+				},
+			],
+		},
+		"rook":
+		{
+			"resources": { "wood" : 13, "mercury": 1, "ore": 13, "sulfur": 1, "crystal": 1, "gems": 1, "gold": 26000, "mithril": 0 },
+			"globalBonuses":
+			[
+				{
+					"type" : "HERO_EXPERIENCE_GAIN_PERCENT",
+					"val" : 39,
+					"duration" : "PERMANENT",
+					"sourceType" : "OTHER"
+				},
+				{
+					"type" : "CREATURE_GROWTH_PERCENT",
+					"val" : 20,
+					"duration" : "PERMANENT",
+					"sourceType" : "OTHER"
+				},
+				{
+					"type" : "GENERATE_RESOURCE",
+					"subtype" : "resource.gold",
+					"val" : 1300,
+					"duration" : "PERMANENT",
+					"sourceType" : "OTHER"
+				},
+				{
+					"type" : "GENERATE_RESOURCE",
+					"subtype" : "resource.wood",
+					"val" : 1,
+					"duration" : "PERMANENT",
+					"sourceType" : "OTHER"
+				},
+				{
+					"type" : "GENERATE_RESOURCE",
+					"subtype" : "resource.ore",
+					"val" : 1,
+					"duration" : "PERMANENT",
+					"sourceType" : "OTHER"
+				},
+				{
+					"type" : "GENERATE_RESOURCE",
+					"subtype" : "resource.mercury",
+					"val" : 1,
+					"duration" : "PERMANENT",
+					"sourceType" : "OTHER"
+				},
+				{
+					"type" : "GENERATE_RESOURCE",
+					"subtype" : "resource.crystal",
+					"val" : 1,
+					"duration" : "PERMANENT",
+					"sourceType" : "OTHER"
+				},
+				{
+					"type" : "GENERATE_RESOURCE",
+					"subtype" : "resource.gems",
+					"val" : 1,
+					"duration" : "PERMANENT",
+					"sourceType" : "OTHER"
+				},
+				{
+					"type" : "GENERATE_RESOURCE",
+					"subtype" : "resource.sulfur",
+					"val" : 1,
+					"duration" : "PERMANENT",
+					"sourceType" : "OTHER"
+				},
+			],
+		},
+		"queen":
+		{
+			"resources": { "wood" : 16, "mercury": 1, "ore": 16, "sulfur": 1, "crystal": 1, "gems": 1, "gold": 32000, "mithril": 0 },
+			"globalBonuses":
+			[
+				{
+					"type" : "HERO_EXPERIENCE_GAIN_PERCENT",
+					"val" : 48,
+					"duration" : "PERMANENT",
+					"sourceType" : "OTHER"
+				},
+				{
+					"type" : "CREATURE_GROWTH_PERCENT",
+					"val" : 25,
+					"duration" : "PERMANENT",
+					"sourceType" : "OTHER"
+				},
+				{
+					"type" : "GENERATE_RESOURCE",
+					"subtype" : "resource.gold",
+					"val" : 400,
+					"duration" : "PERMANENT",
+					"sourceType" : "OTHER"
+				},
+								{
+					"type" : "GENERATE_RESOURCE",
+					"subtype" : "resource.wood",
+					"val" : 1,
+					"duration" : "PERMANENT",
+					"sourceType" : "OTHER"
+				},
+				{
+					"type" : "GENERATE_RESOURCE",
+					"subtype" : "resource.ore",
+					"val" : 1,
+					"duration" : "PERMANENT",
+					"sourceType" : "OTHER"
+				},
+				{
+					"type" : "GENERATE_RESOURCE",
+					"subtype" : "resource.mercury",
+					"val" : 1,
+					"duration" : "PERMANENT",
+					"sourceType" : "OTHER"
+				},
+				{
+					"type" : "GENERATE_RESOURCE",
+					"subtype" : "resource.crystal",
+					"val" : 1,
+					"duration" : "PERMANENT",
+					"sourceType" : "OTHER"
+				},
+				{
+					"type" : "GENERATE_RESOURCE",
+					"subtype" : "resource.gems",
+					"val" : 1,
+					"duration" : "PERMANENT",
+					"sourceType" : "OTHER"
+				},
+				{
+					"type" : "GENERATE_RESOURCE",
+					"subtype" : "resource.sulfur",
+					"val" : 1,
+					"duration" : "PERMANENT",
+					"sourceType" : "OTHER"
+				},
+			],
+		},
+		"king":
+		{
+			"resources": { "wood" : 20, "mercury": 2, "ore": 20, "sulfur": 2, "crystal": 2, "gems": 2, "gold": 40000, "mithril": 0 },
+			"globalBonuses":
+			[
+				{
+					"type" : "HERO_EXPERIENCE_GAIN_PERCENT",
+					"val" : 60,
+					"duration" : "PERMANENT",
+					"sourceType" : "OTHER"
+				},
+				{
+					"type" : "CREATURE_GROWTH_PERCENT",
+					"val" : 30,
+					"duration" : "PERMANENT",
+					"sourceType" : "OTHER"
+				},
+				{
+					"type" : "GENERATE_RESOURCE",
+					"subtype" : "resource.gold",
+					"val" : 500,
+					"duration" : "PERMANENT",
+					"sourceType" : "OTHER"
+				},
+								{
+					"type" : "GENERATE_RESOURCE",
+					"subtype" : "resource.wood",
+					"val" : 1,
+					"duration" : "PERMANENT",
+					"sourceType" : "OTHER"
+				},
+				{
+					"type" : "GENERATE_RESOURCE",
+					"subtype" : "resource.ore",
+					"val" : 1,
+					"duration" : "PERMANENT",
+					"sourceType" : "OTHER"
+				},
+				{
+					"type" : "GENERATE_RESOURCE",
+					"subtype" : "resource.mercury",
+					"val" : 1,
+					"duration" : "PERMANENT",
+					"sourceType" : "OTHER"
+				},
+				{
+					"type" : "GENERATE_RESOURCE",
+					"subtype" : "resource.crystal",
+					"val" : 1,
+					"duration" : "PERMANENT",
+					"sourceType" : "OTHER"
+				},
+				{
+					"type" : "GENERATE_RESOURCE",
+					"subtype" : "resource.gems",
+					"val" : 1,
+					"duration" : "PERMANENT",
+					"sourceType" : "OTHER"
+				},
+				{
+					"type" : "GENERATE_RESOURCE",
+					"subtype" : "resource.sulfur",
+					"val" : 1,
+					"duration" : "PERMANENT",
+					"sourceType" : "OTHER"
+				},
+			],
+		}
+	}
+}
+

--- a/Mods/AI speed up - limit on map heroes/Content/Config/difficulty.json
+++ b/Mods/AI speed up - limit on map heroes/Content/Config/difficulty.json
@@ -22,7 +22,7 @@
 				{
 					"type" : "GENERATE_RESOURCE",
 					"subtype" : "resource.gold",
-					"val" : 185,
+					"val" : 800,
 					"duration" : "PERMANENT",
 					"sourceType" : "OTHER"
 				},
@@ -227,7 +227,7 @@
 				{
 					"type" : "GENERATE_RESOURCE",
 					"subtype" : "resource.gold",
-					"val" : 400,
+					"val" : 1600,
 					"duration" : "PERMANENT",
 					"sourceType" : "OTHER"
 				},
@@ -295,7 +295,7 @@
 				{
 					"type" : "GENERATE_RESOURCE",
 					"subtype" : "resource.gold",
-					"val" : 500,
+					"val" : 2000,
 					"duration" : "PERMANENT",
 					"sourceType" : "OTHER"
 				},

--- a/Mods/AI speed up - limit on map heroes/mod.json
+++ b/Mods/AI speed up - limit on map heroes/mod.json
@@ -10,7 +10,7 @@
 	"keepDisabled" : true,
 	"depends" :
 	[
-    "Boost-ai.Global bonuses for AI",
+	"Boost-ai.Global bonuses for AI",
 	"Boost-ai.Resourceful AI",
 	],
 	"settings" : {

--- a/Mods/AI speed up - limit on map heroes/mod.json
+++ b/Mods/AI speed up - limit on map heroes/mod.json
@@ -1,18 +1,22 @@
 {
 	"name" : "AI speed up - limit on map heroes",
-	"description" : "This option will limt on map heroes to two per player. This way AI will play very fast turns (Nullkiller AI) as it will not do complicated pathfinding/goals or use hero-chains",
-	"version" : "1.2",
+	"description" : "This option will limt on map heroes to two per player for both human and AI. For AI the benefit of this option is that it will end up with strong and high level heroes and will not split armies. It will focus on developing just 2 heroes. AI also gets daily resource/experience/growth bonuses optimized for two heroes on map limit. Bonuses scale with selected game difficulty, and are greater on higher difficulty levels. For human players two hero limit means that map exploration becomes more difficult, as no heroes chains can be used. With this mod turned on, there is also a slight speed increase in AI turns as AI will not do complicated pathfinding/goals or use hero-chains. This might be important for old machines with slow CPUs or games on large maps with 8 players.",
+	"version" : "1.3",
 	"author" : "val-gaav",
 	"licenseName" : "Creative Commons Attribution-ShareAlike",
 	"licenseURL" : "http://creativecommons.org/licenses/by-sa/4.0/deed",
 	"contact" : "http://forum.vcmi.eu/index.php",
 	"modType" : "AI",
 	"keepDisabled" : true,
-	
+	"depends" :
+	[
+    "Boost-ai.Global bonuses for AI",
+	"Boost-ai.Resourceful AI",
+	],
 	"settings" : {
 		"heroes" : {
 			"perPlayerOnMapCap" : 2,
-			"perPlayerTotalCap" : 2
+			"perPlayerTotalCap" : 4
 		}
 	}
 }

--- a/Mods/Battle bonuses for AI/Content/Config/difficulty.json
+++ b/Mods/Battle bonuses for AI/Content/Config/difficulty.json
@@ -8,7 +8,7 @@
 			[
 				{
 					"type" : "STACK_HEALTH",
-					"val" : 25,
+					"val" : 40,
 					"valueType" : "PERCENT_TO_ALL",
 					"duration" : "ONE_BATTLE",
 					"sourceType" : "OTHER"
@@ -46,7 +46,7 @@
 			[
 				{
 					"type" : "STACK_HEALTH",
-					"val" : 100,
+					"val" : 65,
 					"valueType" : "PERCENT_TO_ALL",
 					"duration" : "ONE_BATTLE",
 					"sourceType" : "OTHER"
@@ -65,7 +65,7 @@
 			[
 				{
 					"type" : "STACK_HEALTH",
-					"val" : 150,
+					"val" : 80,
 					"valueType" : "PERCENT_TO_ALL",
 					"duration" : "ONE_BATTLE",
 					"sourceType" : "OTHER"
@@ -84,7 +84,7 @@
 			[
 				{
 					"type" : "STACK_HEALTH",
-					"val" : 200,
+					"val" : 100,
 					"valueType" : "PERCENT_TO_ALL",
 					"duration" : "ONE_BATTLE",
 					"sourceType" : "OTHER"

--- a/Mods/Battle bonuses for AI/mod.json
+++ b/Mods/Battle bonuses for AI/mod.json
@@ -1,7 +1,7 @@
 {
 	"name" : "Battle bonuses for AI",
-	"description" : "Gives advantage for AI player during battles with neutrals.",
-	"version" : "1.0",
+	"description" : "Gives advantage for AI player during battles with neutrals. Bonuses scale with selected game difficulty, and are greater on higher difficulty levels.",
+	"version" : "1.1",
 	"author" : "Nordsoft",
 	"licenseName" : "Creative Commons Attribution-ShareAlike",
 	"licenseURL" : "http://creativecommons.org/licenses/by-sa/4.0/deed",

--- a/Mods/Global bonuses for AI/Content/Config/difficulty.json
+++ b/Mods/Global bonuses for AI/Content/Config/difficulty.json
@@ -8,13 +8,20 @@
 			[
 				{
 					"type" : "HERO_EXPERIENCE_GAIN_PERCENT",
-					"val" : 10,
+					"val" : 24,
 					"duration" : "PERMANENT",
 					"sourceType" : "OTHER"
 				},
 				{
 					"type" : "CREATURE_GROWTH_PERCENT",
-					"val" : 10,
+					"val" : 12,
+					"duration" : "PERMANENT",
+					"sourceType" : "OTHER"
+				},
+				{
+					"type" : "GENERATE_RESOURCE",
+					"subtype" : "resource.gold",
+					"val" : 185,
 					"duration" : "PERMANENT",
 					"sourceType" : "OTHER"
 				},
@@ -32,7 +39,14 @@
 				},
 				{
 					"type" : "CREATURE_GROWTH_PERCENT",
-					"val" : 20,
+					"val" : 15,
+					"duration" : "PERMANENT",
+					"sourceType" : "OTHER"
+				},
+				{
+					"type" : "GENERATE_RESOURCE",
+					"subtype" : "resource.gold",
+					"val" : 250,
 					"duration" : "PERMANENT",
 					"sourceType" : "OTHER"
 				},
@@ -44,13 +58,20 @@
 			[
 				{
 					"type" : "HERO_EXPERIENCE_GAIN_PERCENT",
-					"val" : 50,
+					"val" : 39,
 					"duration" : "PERMANENT",
 					"sourceType" : "OTHER"
 				},
 				{
 					"type" : "CREATURE_GROWTH_PERCENT",
-					"val" : 30,
+					"val" : 20,
+					"duration" : "PERMANENT",
+					"sourceType" : "OTHER"
+				},
+				{
+					"type" : "GENERATE_RESOURCE",
+					"subtype" : "resource.gold",
+					"val" : 325,
 					"duration" : "PERMANENT",
 					"sourceType" : "OTHER"
 				},
@@ -62,13 +83,20 @@
 			[
 				{
 					"type" : "HERO_EXPERIENCE_GAIN_PERCENT",
-					"val" : 80,
+					"val" : 48,
 					"duration" : "PERMANENT",
 					"sourceType" : "OTHER"
 				},
 				{
 					"type" : "CREATURE_GROWTH_PERCENT",
-					"val" : 40,
+					"val" : 25,
+					"duration" : "PERMANENT",
+					"sourceType" : "OTHER"
+				},
+				{
+					"type" : "GENERATE_RESOURCE",
+					"subtype" : "resource.gold",
+					"val" : 400,
 					"duration" : "PERMANENT",
 					"sourceType" : "OTHER"
 				},
@@ -80,13 +108,20 @@
 			[
 				{
 					"type" : "HERO_EXPERIENCE_GAIN_PERCENT",
-					"val" : 100,
+					"val" : 60,
 					"duration" : "PERMANENT",
 					"sourceType" : "OTHER"
 				},
 				{
 					"type" : "CREATURE_GROWTH_PERCENT",
-					"val" : 50,
+					"val" : 30,
+					"duration" : "PERMANENT",
+					"sourceType" : "OTHER"
+				},
+				{
+					"type" : "GENERATE_RESOURCE",
+					"subtype" : "resource.gold",
+					"val" : 500,
 					"duration" : "PERMANENT",
 					"sourceType" : "OTHER"
 				},

--- a/Mods/Global bonuses for AI/mod.json
+++ b/Mods/Global bonuses for AI/mod.json
@@ -1,8 +1,8 @@
 {
 	"name" : "Global bonuses for AI",
-	"description" : "AI heroes gain experience faster and increased creatures growth in AI towns",
-	"version" : "1.0",
-	"author" : "Nordsoft",
+	"description" : "AI heroes generate gold bonuses and gain experience faster, also creatures growth is increased in AI towns. Bonuses scale with selected game difficulty, and are greater on higher difficulty levels.",
+	"version" : "1.1",
+	"author" : "Nordsoft, val-gaav",
 	"licenseName" : "Creative Commons Attribution-ShareAlike",
 	"licenseURL" : "http://creativecommons.org/licenses/by-sa/4.0/deed",
 	"contact" : "http://forum.vcmi.eu/index.php",

--- a/Mods/Resourceful AI/Content/Config/difficulty.json
+++ b/Mods/Resourceful AI/Content/Config/difficulty.json
@@ -4,23 +4,23 @@
 	{
 		"pawn":
 		{
-			"resources": { "wood" : 15, "mercury": 7, "ore": 15, "sulfur": 7, "crystal": 7, "gems": 7, "gold": 15000, "mithril": 0 },
+			"resources": { "wood" : 32, "mercury": 16, "ore": 32, "sulfur": 16, "crystal": 16, "gems": 16, "gold": 16000, "mithril": 0 },
 		},
 		"knight":
 		{
-			"resources": { "wood" : 30, "mercury": 14, "ore": 30, "sulfur": 14, "crystal": 14, "gems": 14, "gold": 30000, "mithril": 0 },
+			"resources": { "wood" : 40, "mercury": 20, "ore": 40, "sulfur": 20, "crystal": 20, "gems": 20, "gold": 20000, "mithril": 0 },
 		},
 		"rook":
 		{
-			"resources": { "wood" : 60, "mercury": 28, "ore": 60, "sulfur": 28, "crystal": 28, "gems": 28, "gold": 60000, "mithril": 0 },
+			"resources": { "wood" : 52, "mercury": 26, "ore": 52, "sulfur": 26, "crystal": 26, "gems": 26, "gold": 26000, "mithril": 0 },
 		},
 		"queen":
 		{
-			"resources": { "wood" : 120, "mercury": 56, "ore": 120, "sulfur": 56, "crystal": 56, "gems": 56, "gold": 120000, "mithril": 0 },
+			"resources": { "wood" : 64, "mercury": 32, "ore": 64, "sulfur": 32, "crystal": 32, "gems": 32, "gold": 32000, "mithril": 0 },
 		},
 		"king":
 		{
-			"resources": { "wood" : 240, "mercury": 112, "ore": 240, "sulfur": 112, "crystal": 112, "gems": 112, "gold": 240000, "mithril": 0 },
+			"resources": { "wood" : 80, "mercury": 40, "ore": 80, "sulfur": 40, "crystal": 40, "gems": 40, "gold": 40000, "mithril": 0 },
 		}
 	},
 }

--- a/Mods/Resourceful AI/mod.json
+++ b/Mods/Resourceful AI/mod.json
@@ -1,7 +1,7 @@
 {
 	"name" : "Resourceful AI",
-	"description" : "Boost AI by giving extra resources so it can quickly develop its towns. Amount of resources depends on selected map difficulty.",
-	"version" : "2.0",
+	"description" : "Boost AI by giving extra starting resources. Bonuses scale with selected game difficulty, and are greater on higher difficulty levels.",
+	"version" : "2.1",
 	"author" : "val-gaav",
 	"licenseName" : "Creative Commons Attribution-ShareAlike",
 	"licenseURL" : "http://creativecommons.org/licenses/by-sa/4.0/deed",

--- a/mod.json
+++ b/mod.json
@@ -1,7 +1,7 @@
 {
 	"name" : "Boost AI",
 	"description" : "Rebalances difficulty system giving AI more advantages. Provides few options for boosting, you can control by enabling/disabling submods",
-	"version" : "0.4",
+	"version" : "0.3",
 	"author" : "Nordsoft, val-gaav",
 	"licenseName" : "Creative Commons Attribution-ShareAlike",
 	"licenseURL" : "http://creativecommons.org/licenses/by-sa/4.0/deed",

--- a/mod.json
+++ b/mod.json
@@ -1,8 +1,8 @@
 {
 	"name" : "Boost AI",
 	"description" : "Rebalances difficulty system giving AI more advantages. Provides few options for boosting, you can control by enabling/disabling submods",
-	"version" : "0.2",
-	"author" : "Nordsoft",
+	"version" : "0.4",
+	"author" : "Nordsoft, val-gaav",
 	"licenseName" : "Creative Commons Attribution-ShareAlike",
 	"licenseURL" : "http://creativecommons.org/licenses/by-sa/4.0/deed",
 	"contact" : "http://forum.vcmi.eu/index.php",


### PR DESCRIPTION
Right now boost ai mod values are an overkill on higher levels if you select all options (I expect most people do that). I have updated them to something that scales with selected difficulty, and did some tests on random maps and some normal maps from SoD.

I've also added daily gold bonus generated per hero, this is a better way to give AI gold it needs, then to do it in starting resources, as it is not an overkill at game start and it will last even on big maps where game may take many months. So it just scales better depending on map size, game time etc. 

The option to limit heroes gets it's own set of bonuses. Here resources are generated daily per hero so AI starts with almost no resources. AI will get two heroes so it will get extra +2 resource each day, the gold bonus is also changed for 2 hero limit. 



