### PR TITLE
NKAI object graph mod and alternative speed-up settings

### DIFF
--- a/Mods/NKAI experimental/Content/Config/ai/nkai/nkai-settings.json
+++ b/Mods/NKAI experimental/Content/Config/ai/nkai/nkai-settings.json
@@ -1,0 +1,5 @@
+{
+	"allowObjectGraph" : true,
+	"mainHeroTurnDistanceLimit" : 2,
+	"scoutHeroTurnDistanceLimit" : 1
+}

--- a/Mods/NKAI experimental/mod.json
+++ b/Mods/NKAI experimental/mod.json
@@ -1,0 +1,11 @@
+{
+	"name" : "NKAI experimental",
+	"description" : "This option changes the way Nullkiller AI calculates paths making it faster but this functionality has not been tested well yet. Should improve speed on big maps.",
+	"version" : "1.0",
+	"author" : "nullkiller",
+	"licenseName" : "Creative Commons Attribution-ShareAlike",
+	"licenseURL" : "http://creativecommons.org/licenses/by-sa/4.0/deed",
+	"contact" : "http://forum.vcmi.eu/index.php",
+	"modType" : "AI",
+	"keepDisabled" : true
+}

--- a/Mods/NKAI speed up - limit on map heroes/Content/Config/ai/nkai/nkai-settings.json
+++ b/Mods/NKAI speed up - limit on map heroes/Content/Config/ai/nkai/nkai-settings.json
@@ -1,0 +1,4 @@
+{
+	"maxRoamingHeroes" : 2,
+	"maxpass" : 10
+}

--- a/Mods/NKAI speed up - limit on map heroes/Content/Config/difficulty.json
+++ b/Mods/NKAI speed up - limit on map heroes/Content/Config/difficulty.json
@@ -1,0 +1,348 @@
+//Configured difficulty
+{
+	"ai":
+	{
+		"pawn":
+		{
+			"resources": { "wood" : 8, "mercury": 1, "ore": 8, "sulfur": 1, "crystal": 1, "gems": 1, "gold": 16000, "mithril": 0 },
+			"globalBonuses":
+			[
+				{
+					"type" : "HERO_EXPERIENCE_GAIN_PERCENT",
+					"val" : 24,
+					"duration" : "PERMANENT",
+					"sourceType" : "OTHER"
+				},
+				{
+					"type" : "CREATURE_GROWTH_PERCENT",
+					"val" : 12,
+					"duration" : "PERMANENT",
+					"sourceType" : "OTHER"
+				},
+				{
+					"type" : "GENERATE_RESOURCE",
+					"subtype" : "resource.gold",
+					"val" : 800,
+					"duration" : "PERMANENT",
+					"sourceType" : "OTHER"
+				},
+								{
+					"type" : "GENERATE_RESOURCE",
+					"subtype" : "resource.wood",
+					"val" : 1,
+					"duration" : "PERMANENT",
+					"sourceType" : "OTHER"
+				},
+				{
+					"type" : "GENERATE_RESOURCE",
+					"subtype" : "resource.ore",
+					"val" : 1,
+					"duration" : "PERMANENT",
+					"sourceType" : "OTHER"
+				},
+				{
+					"type" : "GENERATE_RESOURCE",
+					"subtype" : "resource.mercury",
+					"val" : 1,
+					"duration" : "PERMANENT",
+					"sourceType" : "OTHER"
+				},
+				{
+					"type" : "GENERATE_RESOURCE",
+					"subtype" : "resource.crystal",
+					"val" : 1,
+					"duration" : "PERMANENT",
+					"sourceType" : "OTHER"
+				},
+				{
+					"type" : "GENERATE_RESOURCE",
+					"subtype" : "resource.gems",
+					"val" : 1,
+					"duration" : "PERMANENT",
+					"sourceType" : "OTHER"
+				},
+				{
+					"type" : "GENERATE_RESOURCE",
+					"subtype" : "resource.sulfur",
+					"val" : 1,
+					"duration" : "PERMANENT",
+					"sourceType" : "OTHER"
+				},
+
+			],
+		},
+	"knight":
+		{
+			"resources": { "wood" : 10, "mercury": 1, "ore": 10, "sulfur": 1, "crystal": 1, "gems": 1, "gold": 20000, "mithril": 0 },
+			"globalBonuses":
+			[
+				{
+					"type" : "HERO_EXPERIENCE_GAIN_PERCENT",
+					"val" : 30,
+					"duration" : "PERMANENT",
+					"sourceType" : "OTHER"
+				},
+				{
+					"type" : "CREATURE_GROWTH_PERCENT",
+					"val" : 15,
+					"duration" : "PERMANENT",
+					"sourceType" : "OTHER"
+				},
+				{
+					"type" : "GENERATE_RESOURCE",
+					"subtype" : "resource.gold",
+					"val" : 1000,
+					"duration" : "PERMANENT",
+					"sourceType" : "OTHER"
+				},
+				{
+					"type" : "GENERATE_RESOURCE",
+					"subtype" : "resource.wood",
+					"val" : 1,
+					"duration" : "PERMANENT",
+					"sourceType" : "OTHER"
+				},
+				{
+					"type" : "GENERATE_RESOURCE",
+					"subtype" : "resource.ore",
+					"val" : 1,
+					"duration" : "PERMANENT",
+					"sourceType" : "OTHER"
+				},
+				{
+					"type" : "GENERATE_RESOURCE",
+					"subtype" : "resource.mercury",
+					"val" : 1,
+					"duration" : "PERMANENT",
+					"sourceType" : "OTHER"
+				},
+				{
+					"type" : "GENERATE_RESOURCE",
+					"subtype" : "resource.crystal",
+					"val" : 1,
+					"duration" : "PERMANENT",
+					"sourceType" : "OTHER"
+				},
+				{
+					"type" : "GENERATE_RESOURCE",
+					"subtype" : "resource.gems",
+					"val" : 1,
+					"duration" : "PERMANENT",
+					"sourceType" : "OTHER"
+				},
+				{
+					"type" : "GENERATE_RESOURCE",
+					"subtype" : "resource.sulfur",
+					"val" : 1,
+					"duration" : "PERMANENT",
+					"sourceType" : "OTHER"
+				},
+			],
+		},
+		"rook":
+		{
+			"resources": { "wood" : 13, "mercury": 1, "ore": 13, "sulfur": 1, "crystal": 1, "gems": 1, "gold": 26000, "mithril": 0 },
+			"globalBonuses":
+			[
+				{
+					"type" : "HERO_EXPERIENCE_GAIN_PERCENT",
+					"val" : 39,
+					"duration" : "PERMANENT",
+					"sourceType" : "OTHER"
+				},
+				{
+					"type" : "CREATURE_GROWTH_PERCENT",
+					"val" : 20,
+					"duration" : "PERMANENT",
+					"sourceType" : "OTHER"
+				},
+				{
+					"type" : "GENERATE_RESOURCE",
+					"subtype" : "resource.gold",
+					"val" : 1300,
+					"duration" : "PERMANENT",
+					"sourceType" : "OTHER"
+				},
+				{
+					"type" : "GENERATE_RESOURCE",
+					"subtype" : "resource.wood",
+					"val" : 1,
+					"duration" : "PERMANENT",
+					"sourceType" : "OTHER"
+				},
+				{
+					"type" : "GENERATE_RESOURCE",
+					"subtype" : "resource.ore",
+					"val" : 1,
+					"duration" : "PERMANENT",
+					"sourceType" : "OTHER"
+				},
+				{
+					"type" : "GENERATE_RESOURCE",
+					"subtype" : "resource.mercury",
+					"val" : 1,
+					"duration" : "PERMANENT",
+					"sourceType" : "OTHER"
+				},
+				{
+					"type" : "GENERATE_RESOURCE",
+					"subtype" : "resource.crystal",
+					"val" : 1,
+					"duration" : "PERMANENT",
+					"sourceType" : "OTHER"
+				},
+				{
+					"type" : "GENERATE_RESOURCE",
+					"subtype" : "resource.gems",
+					"val" : 1,
+					"duration" : "PERMANENT",
+					"sourceType" : "OTHER"
+				},
+				{
+					"type" : "GENERATE_RESOURCE",
+					"subtype" : "resource.sulfur",
+					"val" : 1,
+					"duration" : "PERMANENT",
+					"sourceType" : "OTHER"
+				},
+			],
+		},
+		"queen":
+		{
+			"resources": { "wood" : 16, "mercury": 1, "ore": 16, "sulfur": 1, "crystal": 1, "gems": 1, "gold": 32000, "mithril": 0 },
+			"globalBonuses":
+			[
+				{
+					"type" : "HERO_EXPERIENCE_GAIN_PERCENT",
+					"val" : 48,
+					"duration" : "PERMANENT",
+					"sourceType" : "OTHER"
+				},
+				{
+					"type" : "CREATURE_GROWTH_PERCENT",
+					"val" : 25,
+					"duration" : "PERMANENT",
+					"sourceType" : "OTHER"
+				},
+				{
+					"type" : "GENERATE_RESOURCE",
+					"subtype" : "resource.gold",
+					"val" : 1600,
+					"duration" : "PERMANENT",
+					"sourceType" : "OTHER"
+				},
+								{
+					"type" : "GENERATE_RESOURCE",
+					"subtype" : "resource.wood",
+					"val" : 1,
+					"duration" : "PERMANENT",
+					"sourceType" : "OTHER"
+				},
+				{
+					"type" : "GENERATE_RESOURCE",
+					"subtype" : "resource.ore",
+					"val" : 1,
+					"duration" : "PERMANENT",
+					"sourceType" : "OTHER"
+				},
+				{
+					"type" : "GENERATE_RESOURCE",
+					"subtype" : "resource.mercury",
+					"val" : 1,
+					"duration" : "PERMANENT",
+					"sourceType" : "OTHER"
+				},
+				{
+					"type" : "GENERATE_RESOURCE",
+					"subtype" : "resource.crystal",
+					"val" : 1,
+					"duration" : "PERMANENT",
+					"sourceType" : "OTHER"
+				},
+				{
+					"type" : "GENERATE_RESOURCE",
+					"subtype" : "resource.gems",
+					"val" : 1,
+					"duration" : "PERMANENT",
+					"sourceType" : "OTHER"
+				},
+				{
+					"type" : "GENERATE_RESOURCE",
+					"subtype" : "resource.sulfur",
+					"val" : 1,
+					"duration" : "PERMANENT",
+					"sourceType" : "OTHER"
+				},
+			],
+		},
+		"king":
+		{
+			"resources": { "wood" : 20, "mercury": 2, "ore": 20, "sulfur": 2, "crystal": 2, "gems": 2, "gold": 40000, "mithril": 0 },
+			"globalBonuses":
+			[
+				{
+					"type" : "HERO_EXPERIENCE_GAIN_PERCENT",
+					"val" : 60,
+					"duration" : "PERMANENT",
+					"sourceType" : "OTHER"
+				},
+				{
+					"type" : "CREATURE_GROWTH_PERCENT",
+					"val" : 30,
+					"duration" : "PERMANENT",
+					"sourceType" : "OTHER"
+				},
+				{
+					"type" : "GENERATE_RESOURCE",
+					"subtype" : "resource.gold",
+					"val" : 2000,
+					"duration" : "PERMANENT",
+					"sourceType" : "OTHER"
+				},
+								{
+					"type" : "GENERATE_RESOURCE",
+					"subtype" : "resource.wood",
+					"val" : 1,
+					"duration" : "PERMANENT",
+					"sourceType" : "OTHER"
+				},
+				{
+					"type" : "GENERATE_RESOURCE",
+					"subtype" : "resource.ore",
+					"val" : 1,
+					"duration" : "PERMANENT",
+					"sourceType" : "OTHER"
+				},
+				{
+					"type" : "GENERATE_RESOURCE",
+					"subtype" : "resource.mercury",
+					"val" : 1,
+					"duration" : "PERMANENT",
+					"sourceType" : "OTHER"
+				},
+				{
+					"type" : "GENERATE_RESOURCE",
+					"subtype" : "resource.crystal",
+					"val" : 1,
+					"duration" : "PERMANENT",
+					"sourceType" : "OTHER"
+				},
+				{
+					"type" : "GENERATE_RESOURCE",
+					"subtype" : "resource.gems",
+					"val" : 1,
+					"duration" : "PERMANENT",
+					"sourceType" : "OTHER"
+				},
+				{
+					"type" : "GENERATE_RESOURCE",
+					"subtype" : "resource.sulfur",
+					"val" : 1,
+					"duration" : "PERMANENT",
+					"sourceType" : "OTHER"
+				},
+			],
+		}
+	}
+}
+

--- a/Mods/NKAI speed up - limit on map heroes/mod.json
+++ b/Mods/NKAI speed up - limit on map heroes/mod.json
@@ -1,0 +1,16 @@
+{
+	"name" : "NKAI speed up - limit on map heroes",
+	"description" : "This option will limt on map heroes to two per player for only Nullkiller AI. For AI the benefit of this option is that it will end up with strong and high level heroes and will not split armies. It will focus on developing just 2 heroes. AI also gets daily resource/experience/growth bonuses optimized for two heroes on map limit. Bonuses scale with selected game difficulty, and are greater on higher difficulty levels. With this mod turned on, there is also a slight speed increase in AI turns as AI will not do complicated pathfinding/goals or use hero-chains. This might be important for old machines with slow CPUs or games on large maps with 8 players.",
+	"version" : "1.0",
+	"author" : "val-gaav, nullkiller",
+	"licenseName" : "Creative Commons Attribution-ShareAlike",
+	"licenseURL" : "http://creativecommons.org/licenses/by-sa/4.0/deed",
+	"contact" : "http://forum.vcmi.eu/index.php",
+	"modType" : "AI",
+	"keepDisabled" : true,
+	"depends" :
+	[
+		"Boost-ai.Global bonuses for AI",
+		"Boost-ai.Resourceful AI"
+	]
+}

--- a/mod.json
+++ b/mod.json
@@ -1,7 +1,7 @@
 {
 	"name" : "Boost AI",
 	"description" : "Rebalances difficulty system giving AI more advantages. Provides few options for boosting, you can control by enabling/disabling submods",
-	"version" : "0.3",
+	"version" : "0.4",
 	"author" : "Nordsoft, val-gaav",
 	"licenseName" : "Creative Commons Attribution-ShareAlike",
 	"licenseURL" : "http://creativecommons.org/licenses/by-sa/4.0/deed",
@@ -9,6 +9,6 @@
 	"modType" : "AI",
 	"compatibility" :
 	{
-		"min" : "1.4.0"
+		"min" : "1.5.0"
 	}
 }


### PR DESCRIPTION
New option to limit NKAI heroes only (also includes the same boosts as its global counterpart)
New option to enable NKAI unstable and experimental features (currently it is object graph)